### PR TITLE
Use gemini-3.0-flash as default model and add conversion-output guard

### DIFF
--- a/gemini-proxy.php
+++ b/gemini-proxy.php
@@ -15,11 +15,11 @@ $in = json_decode(file_get_contents('php://input'), true);
 if (!is_array($in)) { http_response_code(400); echo json_encode(['error'=>'bad json']); exit; }
 
 // Pull model (default if omitted) and lightly validate
-$model = $in['model'] ?? 'gemini-2.5-flash';
+$model = $in['model'] ?? 'gemini-3.0-flash';
 if (!preg_match('/^[\w.\-:]+$/', $model)) { http_response_code(400); echo json_encode(['error'=>'invalid model']); exit; }
 
 // Optional allowlist (uncomment to lock down)
-// $allowed = ['gemini-2.5-flash','gemini-2.5-pro','gemini-1.5-flash','gemini-1.5-pro'];
+// $allowed = ['gemini-3.0-flash','gemini-2.5-pro','gemini-1.5-flash','gemini-1.5-pro'];
 // if (!in_array($model, $allowed, true)) { http_response_code(400); echo json_encode(['error'=>'model not allowed']); exit; }
 
 // Forward everything else as-is (remove "model" key before forwarding)

--- a/index.html
+++ b/index.html
@@ -1692,7 +1692,7 @@ async function postGemini(payload) {
     if (!isLocal) throw err;
 
     const key = await ensureLocalKey();
-    const model = payload.model || 'gemini-3-flash-preview';
+    const model = payload.model || 'gemini-3.0-flash';
     const direct = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(key)}`,
       {
@@ -1952,7 +1952,7 @@ async function postGemini(payload) {
                     const imagesInstruction = selectedImages.length ? `\n\nFigures: I am including figure image files. Use these exact filenames in <IMG src> where appropriate, and reference them in order of appearance in the text: ${selectedImages.map(f=>f.filename).join(', ')}.` : '';
 
 const responseData = await postGemini({
-  model: 'gemini-2.5-pro',
+  model: 'gemini-3.0-flash',
   contents: [{ parts: [{ text: CONVERSION_PROMPT + imagesInstruction }, ...fileParts, ...imageParts] }],
   generationConfig: { temperature: 0.1, maxOutputTokens: 65000 }
 });
@@ -1962,6 +1962,11 @@ const responseData = await postGemini({
                     let xmlText = responseData.candidates[0].content.parts[0].text;
                     // Remove markdown code block fences if the model adds them
                     xmlText = xmlText.trim().replace(/^```xml\n?/, '').replace(/\n?```$/, '');
+
+                    // Guard against half-finished outputs
+                    if (!xmlText.includes('<PAPER') || !xmlText.includes('</PAPER>')) {
+                      throw new Error('Model output appears incomplete (missing <PAPER> wrapper). Please retry conversion.');
+                    }
 
                     // Sanitize before parsing using allowlist of tags
                     const allowedTags = new Set([
@@ -2544,7 +2549,7 @@ const responseData = await postGemini({
             Please provide a clear, concise answer based ONLY on the paper's content. If there is a single most relevant sentence from the paper that supports your answer (most cases), include it exactly as: <REFERENCE>One VERBATIM SENTENCE REPRODUCED EXACTLY from the paper.</REFERENCE>. Do NOT answer questions unrelated to the paper - just respond, I think that's unrelated to the paper, so I'm afraid I don't have an answer. Math should be written in LaTeX with $...$. Most answers will be a single paragraph; use up to 3 if absolutely necessary to answer the user question. Do not use Markdown in your response. Do NOT say 'based on the paper' or similar: the user knows this conversation is about a paper.`;
 
 const data = await postGemini({
-  model: 'gemini-3-flash-preview',
+  model: 'gemini-3.0-flash',
   contents: [{ parts: [{ text: prompt }] }],
   generationConfig: { temperature: 0.3, maxOutputTokens: 8000 }
 });


### PR DESCRIPTION
### Motivation
- Upgrade the default Gemini model used by the server proxy and client fallbacks to `gemini-3.0-flash` for consistency with newer model availability.
- Keep client/server model configuration aligned so local fallbacks and server proxy behave the same.
- Improve robustness of the conversion flow by detecting incomplete/partial model outputs and surfacing an error instead of quietly proceeding with invalid XML.

### Description
- Changed the default model in `gemini-proxy.php` from `gemini-2.5-flash` to `gemini-3.0-flash` and updated the commented allowlist to reference `gemini-3.0-flash`.
- Updated the web client (`index.html`) to use `gemini-3.0-flash` for conversion and chat calls and to align the local direct-call fallback model to `gemini-3.0-flash`.
- Added a guard after the conversion response to validate that the model output contains a complete `<PAPER>...</PAPER>` wrapper and throw an error if the wrapper is missing.
- Kept existing sanitization/normalization and figure-extraction logic intact while ensuring request paths and model strings are consistent across server and client.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164dc1d9508326a05c693cb6a95315)